### PR TITLE
fix: create LoRA parameters on base weight device instead of CPU

### DIFF
--- a/astrai/model/components/lora.py
+++ b/astrai/model/components/lora.py
@@ -39,8 +39,10 @@ class LoRALinear(nn.Module):
 
         self.r = r
         self.scaling = alpha / r
-        self.lora_A = nn.Parameter(torch.randn(r, self.weight.shape[1]) / r)
-        self.lora_B = nn.Parameter(torch.zeros(self.weight.shape[0], r))
+        device = self.weight.device
+        dtype = self.weight.dtype
+        self.lora_A = nn.Parameter(torch.randn(r, self.weight.shape[1], device=device, dtype=dtype) / r)
+        self.lora_B = nn.Parameter(torch.zeros(self.weight.shape[0], r, device=device, dtype=dtype))
         self._merged = False
 
     def forward(self, x):


### PR DESCRIPTION
## Summary
- When `inject_lora()` replaces `Linear` layers with `LoRALinear` after the model has been moved to CUDA, `lora_A` and `lora_B` were always created on CPU via `torch.randn()` / `torch.zeros()` defaults.
- This caused `RuntimeError: Expected all tensors to be on the same device` during the first forward pass.
- Fix: create `lora_A` and `lora_B` on the same device and dtype as the base weight.

## Test plan
- [x] All 24 existing LoRA unit tests pass
- [x] Manual verification on RTX 4070 Ti SUPER (16GB): model.to('cuda') → inject_lora → forward → train step → merge, all succeed
- [x] Verified on GQA, MLA, and MoE model variants