### PR TITLE
fix: LoRA device mismatch and checkpoint resume

### DIFF
--- a/astrai/trainer/train_context.py
+++ b/astrai/trainer/train_context.py
@@ -110,8 +110,6 @@ class TrainContextBuilder:
 
         def _before_wrap(m):
             m = m.to(device=device)
-            if preloaded_state_dict is not None:
-                m.load_state_dict(preloaded_state_dict, strict=False)
             if cfg.lora is not None:
                 inject_lora(
                     m,
@@ -119,6 +117,8 @@ class TrainContextBuilder:
                     alpha=cfg.lora.alpha,
                     target_modules=set(cfg.lora.target_modules),
                 )
+            if preloaded_state_dict is not None:
+                m.load_state_dict(preloaded_state_dict, strict=False)
             return m
 
         context = TrainContext(


### PR DESCRIPTION
## Summary
- LoRALinear creates lora_A/lora_B on the base weight's device instead of always CPU
- _before_wrap injects LoRA before loading state dict so adapter weights survive checkpoint resume

## Changes
- astrai/model/components/lora.py: lora_A/lora_B now use device=device, dtype=dtype matching the wrapped weight
- astrai/trainer/train_context.py: swapped inject_lora and load_state_dict order